### PR TITLE
Moving the FB.Event.subscribe call inside the window.fbAsyncInit.

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -7,6 +7,10 @@ app.run(function ($rootScope) {
             cookie:true,
             xfbml:true
         });
+        
+        FB.Event.subscribe('auth.statusChange', function(response) {
+            $rootScope.$broadcast("fb_statusChange", {'status': response.status});
+        });
     };
 
     (function (d) {
@@ -20,8 +24,4 @@ app.run(function ($rootScope) {
         js.src = "//connect.facebook.net/en_US/all.js";
         ref.parentNode.insertBefore(js, ref);
     }(document));
-
-    FB.Event.subscribe('auth.statusChange', function(response) {
-        $rootScope.$broadcast("fb_statusChange", {'status': response.status});
-    });
 });


### PR DESCRIPTION
This resolves Issue #3 and is consistent with the Facebook Javascript API help page (https://developers.facebook.com/docs/reference/javascript/).
